### PR TITLE
Fix ElevenLabs widget mobile positioning with safe areas

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -197,3 +197,17 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ElevenLabs Convai widget: ensure it clears mobile browser toolbars/safe areas */
+elevenlabs-convai {
+  position: fixed;
+  right: 16px;
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  z-index: 1000;
+}
+
+@media (max-width: 640px) {
+  elevenlabs-convai {
+    bottom: calc(28px + env(safe-area-inset-bottom));
+  }
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hillcrest Rising Stars - Modern Nursery Platform</title>
+    <title>Rainbow Childcare - Nurturing Young Minds</title>
 
     <!-- PWA Meta Tags -->
     <meta name="application-name" content="Hillcrest Rising Stars" />


### PR DESCRIPTION
## Purpose
Fix the ElevenLabs widget positioning on mobile devices where it was disappearing under the browser URL bar. The user reported that the widget needed more bottom padding to remain visible and accessible on mobile viewports.

## Code changes
- Added CSS positioning rules for `elevenlabs-convai` element with fixed positioning
- Implemented `env(safe-area-inset-bottom)` to respect device safe areas and browser UI
- Added responsive design with increased bottom padding (28px) for screens under 640px width
- Set appropriate z-index (1000) to ensure widget stays above other content
- Updated page title from "Hillcrest Rising Stars" to "Rainbow Childcare"

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c9f04a37b4b24246b61e1eb8f98b7a9a/swoosh-verse)

👀 [Preview Link](https://c9f04a37b4b24246b61e1eb8f98b7a9a-swoosh-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c9f04a37b4b24246b61e1eb8f98b7a9a</projectId>-->
<!--<branchName>swoosh-verse</branchName>-->

## Summary by Sourcery

Fix ElevenLabs widget visibility on mobile by respecting safe-area insets, adding responsive bottom padding, and setting a high z-index; also update the application title.

Bug Fixes:
- Correct mobile positioning of the ElevenLabs Convai widget to prevent it from hiding under browser toolbars by accounting for safe-area insets.

Enhancements:
- Add fixed positioning with env(safe-area-inset-bottom) and increased bottom padding on screens under 640px.
- Set a z-index of 1000 for the widget to ensure it stays above other content.

Documentation:
- Update the page title from "Hillcrest Rising Stars" to "Rainbow Childcare".